### PR TITLE
compare string–comparable dates in same time zone

### DIFF
--- a/index.php
+++ b/index.php
@@ -175,7 +175,7 @@ function espresso_custom_template_display($attributes) {
 	$sql	.= "WHERE e.is_active = 'Y' ";
 
 	//Check shortcodes attributes
-	$sql	.= $show_expired 		== 'false' ? " AND (e.start_date >= '" . date('Y-m-d') . "' OR e.event_status = 'O' OR e.registration_end >= '" . date('Y-m-d') . "') " : '';
+	$sql	.= $show_expired 		== 'false' ? " AND (e.start_date >= '" . current_time('Y-m-d') . "' OR e.event_status = 'O' OR e.registration_end >= '" . current_time('Y-m-d') . "') " : '';
 	$sql	.= $show_deleted 		== 'false' ? " AND e.event_status != 'D' " : "";
 	$sql	.= $show_secondary		== 'false' ? " AND e.event_status != 'S' " : '';
 	$sql	.= $show_recurrence		== 'false' ? " AND e.recurrence_id = '0' " : '';


### PR DESCRIPTION
Depending on your timezone settings in WP > Settings > General, the events may show "closed" too early or too late. Or even drop off the list prematurely (or stay on too long) This PR attempts to fix that by ensuring the datetimes being compared are both in the timezone.

To test, set your site timezone to something other than a timezone equivalent to UTC 0. The further from UTC 0 the better because you'll want UTC 0 to be "tomorrow" and your timezone to be "today" or vice versa. 
Then set up a page with the [EVENT_CUSTOM_VIEW] shortcode.
Then set up some events:
1) One event will start 8-12 hours from now
2) One event that started 8-12 hours ago
3) One event that will close for registration in about 8-12 hours from now
4) One event that closed for registration 8-12 hours ago

With master branch you'll find that events drop off the list or stay on too long. With this branch the events for yesterday should not display, and all of today's events (even events late in the day) should continue to display.